### PR TITLE
修复VS2017下，SolutionDir不正确的问题

### DIFF
--- a/wtf_lib_builder/Build_Debug.bat
+++ b/wtf_lib_builder/Build_Debug.bat
@@ -1,4 +1,4 @@
-MSBuild /nologo /verbosity:m /maxcpucount /p:Configuration="Debug",Platform="Win32" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
-MSBuild /nologo /verbosity:m /maxcpucount /p:Configuration="Debug",Platform="x64" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
+MSBuild /nologo /verbosity:m /maxcpucount /p:SolutionDir="../",Configuration="Debug",Platform="Win32" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
+MSBuild /nologo /verbosity:m /maxcpucount /p:SolutionDir="../",Configuration="Debug",Platform="x64" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
 copy ..\Debug\Win32\*.dll ..\Bililive_dm\Win32\
 copy ..\Debug\x64\*.dll ..\Bililive_dm\x64\

--- a/wtf_lib_builder/Build_Release.bat
+++ b/wtf_lib_builder/Build_Release.bat
@@ -1,4 +1,4 @@
-MSBuild /nologo /verbosity:m /maxcpucount /p:Configuration="Release",Platform="Win32" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
-MSBuild /nologo /verbosity:m /maxcpucount /p:Configuration="Release",Platform="x64" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
+MSBuild /nologo /verbosity:m /maxcpucount /p:SolutionDir="../",Configuration="Release",Platform="Win32" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
+MSBuild /nologo /verbosity:m /maxcpucount /p:SolutionDir="../",Configuration="Release",Platform="x64" "../libwtfdanmaku/libwtfdanmaku.vcxproj"
 copy ..\Release\Win32\*.dll ..\Bililive_dm\Win32\
 copy ..\Release\x64\*.dll ..\Bililive_dm\x64\


### PR DESCRIPTION
hi
我是用2017时，wtf_lib_builder的bat，build libwtfdanmaku的输出没有输出到SolutionDir下，这是因为bat中执行MSBuild时，SolutionDir为当前项目的默认值。
机理我并不是很清楚，但是现象就是如此，可以在bat中改/verbosity:diag，可以看到输出目录确实是libwtfdanmaku项目的默认输出目录，而非SolutionDir正确指定情况下的目录。
不知道你是否要支持其他版本VS，我这里2017是这样的。