### PR TITLE
[PR Test] Plugins Table Status i18n

### DIFF
--- a/Bililive_dm/PluginStatusConverter.cs
+++ b/Bililive_dm/PluginStatusConverter.cs
@@ -11,11 +11,11 @@ namespace Bililive_dm
 
             if ((bool) value == true)
             {
-                return "已啟用";
+                return Properties.Resources.Plugin_DataGrid_Status_On;
             }
             else
             {
-                return "未啟用";
+                return Properties.Resources.Plugin_DataGrid_Status_Off;
             }
         }
 

--- a/Bililive_dm/Properties/Resources.Designer.cs
+++ b/Bililive_dm/Properties/Resources.Designer.cs
@@ -1194,5 +1194,23 @@ namespace Bililive_dm.Properties {
                 return ResourceManager.GetString("WTFEngineEnable.Content", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   查找类似 已啟用 的本地化字符串。
+        /// </summary>
+        public static string Plugin_DataGrid_Status_On {
+            get {
+                return ResourceManager.GetString("Plugin_DataGrid_Status_On", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 未啟用 的本地化字符串。
+        /// </summary>
+        public static string Plugin_DataGrid_Status_Off {
+            get {
+                return ResourceManager.GetString("Plugin_DataGrid_Status_Off", resourceCulture);
+            }
+        }
     }
 }

--- a/Bililive_dm/Properties/Resources.en-JA.resx
+++ b/Bililive_dm/Properties/Resources.en-JA.resx
@@ -496,4 +496,10 @@
   <data name="MainWindow_ProcDanmaku_歡迎老爺和管理員__0__進入直播間" xml:space="preserve">
     <value>歡迎老爺和管理員 {0} 進入直播間</value>
   </data>
+  <data name="Plugin_DataGrid_Status_On" xml:space="preserve">
+    <value>已啟用</value>
+  </data>
+  <data name="Plugin_DataGrid_Status_Off" xml:space="preserve">
+    <value>未啟用</value>
+  </data>
 </root>

--- a/Bililive_dm/Properties/Resources.en-US.resx
+++ b/Bililive_dm/Properties/Resources.en-US.resx
@@ -496,4 +496,10 @@ Information:</value>
   <data name="MainWindow_ProcDanmaku_歡迎老爺和管理員__0__進入直播間" xml:space="preserve">
     <value>Welcome VIP and Moderator {0} entered your stream</value>
   </data>
+  <data name="Plugin_DataGrid_Status_On" xml:space="preserve">
+    <value>ON</value>
+  </data>
+  <data name="Plugin_DataGrid_Status_Off" xml:space="preserve">
+    <value>OFF</value>
+  </data>
 </root>

--- a/Bililive_dm/Properties/Resources.ja-JP.resx
+++ b/Bililive_dm/Properties/Resources.ja-JP.resx
@@ -496,4 +496,10 @@
   <data name="MainWindow_ProcDanmaku_歡迎老爺和管理員__0__進入直播間" xml:space="preserve">
     <value>[マスター][管理者] {1}さん 入室した</value>
   </data>
+  <data name="Plugin_DataGrid_Status_On" xml:space="preserve">
+    <value>オン</value>
+  </data>
+  <data name="Plugin_DataGrid_Status_Off" xml:space="preserve">
+    <value>オフ</value>
+  </data>
 </root>

--- a/Bililive_dm/Properties/Resources.resx
+++ b/Bililive_dm/Properties/Resources.resx
@@ -496,4 +496,10 @@
   <data name="MainWindow_ProcDanmaku_歡迎老爺和管理員__0__進入直播間" xml:space="preserve">
     <value>歡迎老爺和管理員 {0} 進入直播間</value>
   </data>
+  <data name="Plugin_DataGrid_Status_On" xml:space="preserve">
+    <value>已啟用</value>
+  </data>
+  <data name="Plugin_DataGrid_Status_Off" xml:space="preserve">
+    <value>未啟用</value>
+  </data>
 </root>


### PR DESCRIPTION
<details>
<summary>[PR Test] Plugins Table Status i18n</summary>
[测试PR] 插件表格的状态显示尚未完全国际化，故进行国际化
</details>

![](https://img-blog.csdnimg.cn/2021052623070834.png)