### PR TITLE
修复反选弹幕checkbox时可能出现的崩溃问题

### DIFF
--- a/Bililive_dm/MainWindow.xaml.cs
+++ b/Bililive_dm/MainWindow.xaml.cs
@@ -1122,7 +1122,7 @@ namespace Bililive_dm
             //            overlay.Show();
             _fulloverlayEnabled = true;
             OpenFullOverlay();
-            _fulloverlay.Show();
+            //_fulloverlay.Show();
         }
 
         private void SideBar_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
MainWindow::_fulloverlay.Show()被重复调用使Controller::working()被重复Start，导致DanmakusRetainer::Clear()在执行时3个指针可能指向错误的地址而引发崩溃